### PR TITLE
webui: redirect without a leading slash to $loc

### DIFF
--- a/webui/lib/functions.lib.php
+++ b/webui/lib/functions.lib.php
@@ -132,7 +132,8 @@ function show_notification() {
 }
 
 function redirect($loc) {
-	header('Location: '.$loc);
+	// Redirect to $loc without a leading slash
+	header('Location: '.ltrim($loc,'/'));
 	exit;
 }
 


### PR DESCRIPTION
Fix for double slashes in redirected URLs.