### PR TITLE
Disable autocomplete for TOTP login input field 

### DIFF
--- a/api/lib/vpsadmin/api/authentication/oauth2_authorize.erb
+++ b/api/lib/vpsadmin/api/authentication/oauth2_authorize.erb
@@ -226,7 +226,7 @@
                         <div class="input-group-prepend">
                           <span class="input-group-text"> <i class="fa fa-lock"></i> </span>
                         </div>
-                        <input type="text" class="form-control" name="totp_code" id="totp_code" placeholder="TOTP code" autofocus>
+                        <input type="text" class="form-control" name="totp_code" id="totp_code" placeholder="TOTP code" autocomplete="off" autofocus>
                       </div>
                     </div>
 


### PR DESCRIPTION
Currently my browser remembers every previous TOTP code and suggest it during TOTP login. This PR disables autocomplete feature for this TOTP input field.