### PR TITLE
api: allow setting null MX records

### DIFF
--- a/api/models/dns_record.rb
+++ b/api/models/dns_record.rb
@@ -95,7 +95,12 @@ class DnsRecord < ApplicationRecord
         errors.add(:content, 'must be an IPv6 address, not IPv4')
       end
 
-    when 'CNAME', 'MX', 'NS', 'PTR'
+    when 'MX'
+      unless (priority == 0 && content == '.') || valid_fqdn?(content)
+        errors.add(:content, 'must be a fully qualified domain name or null record')
+      end
+
+    when 'CNAME', 'NS', 'PTR'
       unless valid_fqdn?(content)
         errors.add(:content, 'must be a fully qualified domain name')
       end


### PR DESCRIPTION
RFC 7505 defines a way to indicate that a given domain doesn't receive
mail to prevent falling back to the A/AAAA record. This is done by
setting a single MX record with priority 0 and host . (a dot). Modify
the request validation not to reject such combination.

---

Toto je poprvé, co vidím Ruby, a zároveň nemám možnost vyzkoušet, že to dělá to, co si myslím, že to dělá, tak prosím o speciální kontrolu.

RFC 7505 specifikuje, že takový MX záznam musí být pro danou doménu jediný -- to zde nijak nekontroluji. Nevím tedy, zda to rovnou nezjednodušit i o kontrolu nulovosti priority, kterou RFC také zmiňuje, a nechat sémantickou správnost záznamu plně na odpovědnosti uživatele.

Experimentoval jsem také s tím, že by byl odesílaný content prázdný string, ale tečka mi přijde explicitnější a zdá se mi, že ji vpsadmin do výsledného záznamu neduplikuje.

Nemýlím-li se, vpsadmin aktuálně neumožňuje nastavovat ani nulové SRV záznamy, to však nechávám na někdy příště :-)
